### PR TITLE
Refactor chat server architecture and add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/build/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+*.o
+*.obj
+*.swp
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+project(StandardCPPServer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(chat_server
+    src/main.cpp
+    src/chat_server.cpp
+)
+
+target_include_directories(chat_server PRIVATE include)
+
+target_compile_options(chat_server PRIVATE -Wall -Wextra -Wpedantic)
+
+target_link_libraries(chat_server PRIVATE pthread)

--- a/docs/annotated_walkthrough.md
+++ b/docs/annotated_walkthrough.md
@@ -1,0 +1,119 @@
+# 代码逐行讲解（Annotated Walkthrough）
+
+> 目标读者：第一次接触 Linux 下 C++ 网络编程的同学。
+>
+> 作用：帮助你理解每一块代码存在的意义，未来扩展时也能快速定位需要修改的地方。
+
+## 架构全景
+
+本项目由三个核心部分构成：
+
+1. `ThreadPool` —— 一个可复用的线程池，负责异步广播消息。
+2. `ChatServer` —— 业务核心，封装了 socket、epoll 以及连接管理逻辑。
+3. `main` —— 入口函数，只做最小化的初始化与回调配置。
+
+CMake 构建脚本会把 `src/main.cpp` 和 `src/chat_server.cpp` 编译成一个名为 `chat_server` 的可执行文件。
+
+下文将按照“线程池 → 服务器类 → 入口”的顺序逐段讲解。
+
+---
+
+## include/thread_pool.h
+
+### 设计理念
+
+- **固定线程数**：构造函数里创建线程，析构时回收，避免频繁创建销毁线程的开销。
+- **任务队列**：任何需要异步执行的函数都被包装后丢到 `std::queue` 里，工作线程会不断取出并执行。
+- **阻塞等待**：通过 `std::condition_variable` 在任务队列为空时阻塞线程，避免空转。
+
+### 关键成员说明
+
+| 成员 | 作用 |
+| ---- | ---- |
+| `workers_` | 真正干活的线程列表 |
+| `tasks_` | 待执行任务队列 |
+| `mutex_` | 保护 `tasks_` 和 `stop_` |
+| `condition_` | 通知工作线程有新任务 |
+| `stop_` | 线程池是否已经停止 |
+
+### enqueue 的流程
+
+1. `std::packaged_task` 将任意可调用对象包裹成共享状态，便于获取返回值。
+2. 通过锁把任务丢进队列。
+3. `notify_one` 唤醒一个等待的工作线程。
+4. 工作线程在 `workerLoop()` 中醒来，取出任务并执行。
+
+> 小练习：尝试在 `workerLoop()` 中加入日志，打印当前线程 ID，观察任务在不同线程之间的调度情况。
+
+---
+
+## include/chat_server.h & src/chat_server.cpp
+
+### 构造函数与析构函数
+
+- 构造函数仅负责保存配置与构建线程池。
+- 析构函数里保证所有资源（监听 socket、epoll fd、客户端 fd）都被关闭。即便 `run()` 抛出异常或提前返回，也不会泄露资源。
+
+### run()
+
+1. 调用 `prepare_listening_socket()` 创建监听 socket 并设置为非阻塞。
+2. 调用 `register_listen_socket()` 将监听 fd 加入 epoll。
+3. 开始 `event_loop()`，进入无限循环等待事件。
+
+若任一步失败，会打印错误并返回 `false`，提示主函数退出。
+
+### event_loop()
+
+- `epoll_wait` 会阻塞直到有事件发生；返回值 `ready` 表示就绪事件数量。
+- 对于监听 fd，调用 `handle_new_connection()`；
+- 对于客户端 fd，调用 `handle_client_event()`。
+
+### handle_new_connection()
+
+- 使用 `accept` 接受所有准备好的连接，直到返回 `EAGAIN/EWOULDBLOCK`，表示没有更多等待的连接。
+- 新连接设置成非阻塞，并加入 epoll 监听读事件。
+- 将 fd 存入 `clients_` 集合，方便广播时获取在线列表。
+- 如果设置了 `on_client_connected_` 回调，就调用；否则打印默认日志。
+
+### handle_client_event()
+
+- 任何错误事件（`EPOLLERR/EPOLLHUP/EPOLLRDHUP`）都会调用 `close_client()` 关闭连接。
+- 对于可读事件：持续调用 `recv`，把数据拼接到 `message` 字符串里。
+- 如果 `recv` 返回 0，说明对端主动断开；调用 `close_client()`。
+- 如果成功读取到数据，触发 `on_message_` 回调，并把广播任务提交给线程池。
+
+### broadcast_message()
+
+- 先复制一份当前在线 fd 列表（快照），避免发送时长时间持有锁。
+- 逐个发送消息，遇到 `EAGAIN/EWOULDBLOCK` 会继续尝试；其他错误或返回 0 则关闭对应客户端。
+
+### close_client()
+
+- 从 epoll 中移除该 fd。
+- 关闭 fd，并从客户端集合里擦除。
+- 如果设置了 `on_client_disconnected_`，就调用回调；否则打印日志。
+
+> 扩展练习：尝试在回调里维护“用户昵称 → fd”的映射，这样就可以在 `on_message_` 中识别是谁发的消息。
+
+---
+
+## src/main.cpp
+
+主函数保持极简：
+
+1. 忽略 `SIGPIPE`，防止写入已关闭连接时进程异常退出。
+2. 读取命令行参数作为监听端口。
+3. 构造 `ChatServer` 并设置三个回调：连接、断开、收到消息。
+4. 调用 `run()`，若失败则返回非零值给操作系统。
+
+> 小练习：试着在命令行传入 `./chat_server 6666`，体验自定义端口。
+
+---
+
+## 下一步可以做什么？
+
+1. **添加昵称/登录功能**：可以在 `on_client_connected_` 里发送欢迎消息，或在 `on_message_` 里解析命令。
+2. **持久化聊天记录**：把 `on_message_` 里的内容写入文件或数据库。
+3. **优雅退出**：增加一个信号处理器（如捕获 `SIGINT`），在其中把 `running_` 设为 `false`，让 `event_loop()` 退出。
+
+希望这份文档能成为你继续深入学习的起点！

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,104 @@
+# 新手教学：从零搭建 epoll + 线程池聊天室服务器
+
+> 建议边看边实践，把文中的命令在终端里亲自敲一遍。
+
+## 0. 环境准备
+
+- 操作系统：Linux（Ubuntu、Debian、Arch 等都可以）。
+- 编译器：g++ 9 以上（需要 C++17）。
+- 构建工具：CMake 3.16+。
+
+验证命令：
+
+```bash
+cmake --version
+g++ --version
+```
+
+## 1. 获取代码
+
+```bash
+git clone <你的仓库地址>
+cd StandardCPPServer
+```
+
+目录结构说明：
+
+```
+├── CMakeLists.txt        # 构建脚本
+├── include               # 头文件目录（对外接口 + 工具类）
+│   ├── chat_server.h
+│   └── thread_pool.h
+├── src                   # 源文件目录
+│   ├── chat_server.cpp
+│   └── main.cpp
+└── docs                  # 文档目录
+    ├── annotated_walkthrough.md
+    └── tutorial.md
+```
+
+## 2. 构建与运行
+
+```bash
+cmake -S . -B build
+cmake --build build
+./build/chat_server 5555
+```
+
+> 如果想换端口，只需要把最后一个参数改掉即可。
+
+## 3. 打开两个终端测试
+
+1. 终端 A：运行服务器 `./build/chat_server`。
+2. 终端 B：使用 `nc` 连接服务器 `nc 127.0.0.1 5555`。
+3. 终端 C：再打开一个 `nc 127.0.0.1 5555`。
+
+现在在终端 B 输入任何内容，终端 C 都会收到同样的内容（反之亦然）。
+
+## 4. 自己动手拓展功能
+
+### 4.1 定制回调
+
+在 `src/main.cpp` 里我们已经示范了如何注入回调。如果你希望在有人加入时发送欢迎消息，可以这么写：
+
+```cpp
+server.set_on_client_connected([&server](int fd, const sockaddr_in& addr) {
+    (void)addr; // 暂时用不到 IP 信息
+    const std::string welcome = "Welcome! 输入内容即可广播给所有人\n";
+    ::send(fd, welcome.data(), welcome.size(), MSG_NOSIGNAL);
+});
+```
+
+### 4.2 消息协议
+
+当前实现是一个“纯文本广播”。如果想把消息改成“昵称: 内容”的格式，可以在 `on_message` 回调里解析：
+
+```cpp
+server.set_on_message([](int fd, const std::string& message) {
+    std::cout << "[DEBUG] 原始数据: " << message << std::endl;
+    // TODO: 在这里解析命令，比如 /nick Alice
+});
+```
+
+### 4.3 优雅退出
+
+1. 在 `ChatServer` 里添加 `stop()` 方法，把 `running_` 设为 `false`。
+2. 在 `main` 里捕获 `SIGINT`，调用 `stop()` 并唤醒 `epoll_wait`。
+3. 可以用 `eventfd` 或往监听 socket 写数据来唤醒阻塞的 `epoll_wait`。
+
+## 5. 常见问题排查
+
+| 问题 | 可能原因 | 解决思路 |
+| ---- | -------- | -------- |
+| 编译报错 `pthread` | 忘记安装 `libpthread`（glibc 自带）或链接 | 确认 `target_link_libraries` 已包含 `pthread` |
+| 运行时报 `Address already in use` | 端口被占用 | 改端口，或等待旧进程释放端口 |
+| 客户端连接后立刻断开 | 防火墙或 `send` 失败 | 查看服务器日志，确认没有触发 `close_client` |
+
+## 6. 推荐的下一步学习路线
+
+1. 了解 `epoll` 的边缘触发（ET）模式，并尝试改写 `ChatServer`。
+2. 引入日志库（如 spdlog）替换 `std::cout`，了解日志级别与格式化输出。
+3. 为线程池增加任务优先级或动态扩容能力。
+4. 使用 `std::span`（C++20）或 `asio` 等库体验不同的网络抽象。
+
+祝学习愉快！

--- a/include/chat_server.h
+++ b/include/chat_server.h
@@ -1,0 +1,69 @@
+#ifndef STANDARD_CPP_SERVER_CHAT_SERVER_H
+#define STANDARD_CPP_SERVER_CHAT_SERVER_H
+
+#include "thread_pool.h"
+
+#include <netinet/in.h>
+#include <sys/epoll.h>
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_set>
+
+// ChatServer 封装了一个使用 epoll + 线程池的多人聊天室服务端。
+//
+// 设计目标：
+// 1. 保持 main 函数简单，仅负责解析参数与启动服务。
+// 2. 将 socket/epoll 的细节收敛在类内部，便于扩展新的功能。
+// 3. 对外暴露少量接口，方便初学者理解生命周期。
+class ChatServer {
+public:
+    struct Config {
+        int port = 5555;                       // 监听端口
+        int max_events = 64;                   // epoll 每次返回的最大事件数
+        std::size_t read_buffer_size = 4096;   // 单次读取缓冲区大小
+        std::size_t worker_threads = std::max<std::size_t>(2, std::thread::hardware_concurrency());
+    };
+
+    explicit ChatServer(Config config);
+    ~ChatServer();
+
+    // 启动服务器。返回 true 表示正常退出，false 表示初始化或运行过程中出现错误。
+    bool run();
+
+    // 允许在运行前自定义连接建立/断开/消息到达时的回调，方便日后扩展业务逻辑。
+    void set_on_client_connected(std::function<void(int, const sockaddr_in&)> callback);
+    void set_on_client_disconnected(std::function<void(int)> callback);
+    void set_on_message(std::function<void(int, const std::string&)> callback);
+
+private:
+    bool prepare_listening_socket();
+    bool register_listen_socket();
+    bool event_loop();
+
+    void handle_new_connection();
+    void handle_client_event(int client_fd, uint32_t events);
+    void close_client(int client_fd);
+
+    void broadcast_message(const std::string& message, int sender_fd);
+
+    Config config_;
+    ThreadPool thread_pool_;
+
+    int listen_fd_ = -1;
+    int epoll_fd_ = -1;
+
+    std::unordered_set<int> clients_;
+    std::mutex clients_mutex_;
+
+    std::function<void(int, const sockaddr_in&)> on_client_connected_;
+    std::function<void(int)> on_client_disconnected_;
+    std::function<void(int, const std::string&)> on_message_;
+
+    std::atomic<bool> running_{false};
+};
+
+#endif  // STANDARD_CPP_SERVER_CHAT_SERVER_H

--- a/include/thread_pool.h
+++ b/include/thread_pool.h
@@ -1,0 +1,87 @@
+#ifndef STANDARD_CPP_SERVER_THREAD_POOL_H
+#define STANDARD_CPP_SERVER_THREAD_POOL_H
+
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+// ThreadPool 是一个简单的任务队列实现，负责复用固定数量的工作线程。
+// 本实现面向教学：代码尽可能少用模板技巧，便于初学者理解并在此基础上扩展。
+class ThreadPool {
+public:
+    explicit ThreadPool(std::size_t thread_count)
+        : stop_(false) {
+        if (thread_count == 0) {
+            thread_count = 1;
+        }
+        for (std::size_t i = 0; i < thread_count; ++i) {
+            workers_.emplace_back([this]() { this->workerLoop(); });
+        }
+    }
+
+    ThreadPool(const ThreadPool&) = delete;
+    ThreadPool& operator=(const ThreadPool&) = delete;
+
+    ~ThreadPool() {
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            stop_ = true;
+        }
+        condition_.notify_all();
+        for (auto& worker : workers_) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+    }
+
+    template <typename F, typename... Args>
+    auto enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>> {
+        using ReturnType = std::invoke_result_t<F, Args...>;
+
+        auto task = std::make_shared<std::packaged_task<ReturnType()>>(
+            std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (stop_) {
+                throw std::runtime_error("enqueue on stopped ThreadPool");
+            }
+            tasks_.emplace([task]() { (*task)(); });
+        }
+
+        condition_.notify_one();
+        return task->get_future();
+    }
+
+private:
+    void workerLoop() {
+        while (true) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                condition_.wait(lock, [this]() { return stop_ || !tasks_.empty(); });
+                if (stop_ && tasks_.empty()) {
+                    return;
+                }
+                task = std::move(tasks_.front());
+                tasks_.pop();
+            }
+            task();
+        }
+    }
+
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool stop_;
+};
+
+#endif  // STANDARD_CPP_SERVER_THREAD_POOL_H

--- a/src/chat_server.cpp
+++ b/src/chat_server.cpp
@@ -1,0 +1,303 @@
+#include "chat_server.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+namespace {
+int set_non_blocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags == -1) {
+        return -1;
+    }
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+void close_quietly(int fd) {
+    if (fd >= 0) {
+        ::close(fd);
+    }
+}
+}  // namespace
+
+ChatServer::ChatServer(Config config)
+    : config_(config), thread_pool_(config.worker_threads) {}
+
+ChatServer::~ChatServer() {
+    running_.store(false);
+    close_quietly(listen_fd_);
+    close_quietly(epoll_fd_);
+    {
+        std::lock_guard<std::mutex> lock(clients_mutex_);
+        for (int client_fd : clients_) {
+            close_quietly(client_fd);
+        }
+    }
+}
+
+bool ChatServer::run() {
+    if (running_.load()) {
+        return false;
+    }
+
+    if (!prepare_listening_socket()) {
+        return false;
+    }
+
+    if (!register_listen_socket()) {
+        return false;
+    }
+
+    running_.store(true);
+    bool success = event_loop();
+    running_.store(false);
+    return success;
+}
+
+void ChatServer::set_on_client_connected(std::function<void(int, const sockaddr_in&)> callback) {
+    on_client_connected_ = std::move(callback);
+}
+
+void ChatServer::set_on_client_disconnected(std::function<void(int)> callback) {
+    on_client_disconnected_ = std::move(callback);
+}
+
+void ChatServer::set_on_message(std::function<void(int, const std::string&)> callback) {
+    on_message_ = std::move(callback);
+}
+
+bool ChatServer::prepare_listening_socket() {
+    listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd_ < 0) {
+        std::perror("socket");
+        return false;
+    }
+
+    int enable = 1;
+    if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+        std::perror("setsockopt");
+        return false;
+    }
+
+    if (set_non_blocking(listen_fd_) < 0) {
+        std::perror("fcntl");
+        return false;
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(static_cast<uint16_t>(config_.port));
+
+    if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        std::perror("bind");
+        return false;
+    }
+
+    if (listen(listen_fd_, SOMAXCONN) < 0) {
+        std::perror("listen");
+        return false;
+    }
+
+    return true;
+}
+
+bool ChatServer::register_listen_socket() {
+    epoll_fd_ = epoll_create1(0);
+    if (epoll_fd_ < 0) {
+        std::perror("epoll_create1");
+        return false;
+    }
+
+    epoll_event event{};
+    event.data.fd = listen_fd_;
+    event.events = EPOLLIN;
+
+    if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, listen_fd_, &event) < 0) {
+        std::perror("epoll_ctl: listen_fd");
+        return false;
+    }
+
+    return true;
+}
+
+bool ChatServer::event_loop() {
+    std::vector<epoll_event> events(static_cast<std::size_t>(config_.max_events));
+
+    std::cout << "Chat server listening on port " << config_.port << std::endl;
+
+    while (running_.load()) {
+        int ready = epoll_wait(epoll_fd_, events.data(), config_.max_events, -1);
+        if (ready < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            std::perror("epoll_wait");
+            return false;
+        }
+
+        for (int i = 0; i < ready; ++i) {
+            int fd = events[i].data.fd;
+            uint32_t ev = events[i].events;
+
+            if (fd == listen_fd_) {
+                handle_new_connection();
+                continue;
+            }
+
+            handle_client_event(fd, ev);
+        }
+    }
+
+    return true;
+}
+
+void ChatServer::handle_new_connection() {
+    while (true) {
+        sockaddr_in client_addr{};
+        socklen_t client_len = sizeof(client_addr);
+        int client_fd = accept(listen_fd_, reinterpret_cast<sockaddr*>(&client_addr), &client_len);
+        if (client_fd < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            std::perror("accept");
+            break;
+        }
+
+        if (set_non_blocking(client_fd) < 0) {
+            std::perror("fcntl: client");
+            close_quietly(client_fd);
+            continue;
+        }
+
+        epoll_event client_event{};
+        client_event.data.fd = client_fd;
+        client_event.events = EPOLLIN | EPOLLRDHUP | EPOLLHUP | EPOLLERR;
+
+        if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, client_fd, &client_event) < 0) {
+            std::perror("epoll_ctl: client");
+            close_quietly(client_fd);
+            continue;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(clients_mutex_);
+            clients_.insert(client_fd);
+        }
+
+        if (on_client_connected_) {
+            on_client_connected_(client_fd, client_addr);
+        } else {
+            char addr_buffer[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, &client_addr.sin_addr, addr_buffer, sizeof(addr_buffer));
+            std::cout << "New connection from " << addr_buffer << ":" << ntohs(client_addr.sin_port)
+                      << " (fd=" << client_fd << ")" << std::endl;
+        }
+    }
+}
+
+void ChatServer::handle_client_event(int client_fd, uint32_t events) {
+    if ((events & EPOLLERR) || (events & EPOLLHUP) || (events & EPOLLRDHUP)) {
+        close_client(client_fd);
+        return;
+    }
+
+    if (events & EPOLLIN) {
+        std::string message;
+        bool connection_closed = false;
+
+        while (true) {
+            std::vector<char> buffer(config_.read_buffer_size);
+            ssize_t count = ::recv(client_fd, buffer.data(), buffer.size(), 0);
+            if (count < 0) {
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    break;
+                }
+                std::perror("recv");
+                connection_closed = true;
+                break;
+            }
+            if (count == 0) {
+                connection_closed = true;
+                break;
+            }
+
+            message.append(buffer.data(), buffer.data() + count);
+
+            if (static_cast<std::size_t>(count) < buffer.size()) {
+                break;
+            }
+        }
+
+        if (connection_closed) {
+            close_client(client_fd);
+            return;
+        }
+
+        if (!message.empty()) {
+            if (on_message_) {
+                on_message_(client_fd, message);
+            }
+            thread_pool_.enqueue([this, message, client_fd]() { broadcast_message(message, client_fd); });
+        }
+    }
+}
+
+void ChatServer::close_client(int client_fd) {
+    epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, client_fd, nullptr);
+    close_quietly(client_fd);
+
+    {
+        std::lock_guard<std::mutex> lock(clients_mutex_);
+        clients_.erase(client_fd);
+    }
+
+    if (on_client_disconnected_) {
+        on_client_disconnected_(client_fd);
+    } else {
+        std::cout << "Client disconnected: " << client_fd << std::endl;
+    }
+}
+
+void ChatServer::broadcast_message(const std::string& message, int sender_fd) {
+    std::vector<int> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(clients_mutex_);
+        snapshot.assign(clients_.begin(), clients_.end());
+    }
+
+    for (int client_fd : snapshot) {
+        if (client_fd == sender_fd) {
+            continue;
+        }
+
+        ssize_t total_sent = 0;
+        while (total_sent < static_cast<ssize_t>(message.size())) {
+            ssize_t sent = ::send(client_fd, message.data() + total_sent,
+                                  message.size() - static_cast<std::size_t>(total_sent), MSG_NOSIGNAL);
+            if (sent < 0) {
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    continue;
+                }
+                close_client(client_fd);
+                break;
+            }
+            if (sent == 0) {
+                close_client(client_fd);
+                break;
+            }
+            total_sent += sent;
+        }
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,45 @@
+#include "chat_server.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <csignal>
+#include <iostream>
+
+// 主函数只负责：
+// 1. 捕获 SIGPIPE，防止写入已关闭的 socket 时程序直接退出。
+// 2. 解析命令行参数（如果给定）来指定端口。
+// 3. 创建 ChatServer 对象并运行。
+int main(int argc, char* argv[]) {
+    std::signal(SIGPIPE, SIG_IGN);
+
+    ChatServer::Config config;
+    if (argc > 1) {
+        config.port = std::stoi(argv[1]);
+    }
+
+    ChatServer server(config);
+
+    // 初学者可以在这里配置自定义的回调，以便打印更详细的日志，
+    // 或者接入数据库、业务逻辑等。
+    server.set_on_client_connected([](int fd, const sockaddr_in& addr) {
+        char buffer[INET_ADDRSTRLEN] = {0};
+        inet_ntop(AF_INET, &addr.sin_addr, buffer, sizeof(buffer));
+        std::cout << "[INFO] 新客户端连接: " << buffer << ":" << ntohs(addr.sin_port)
+                  << " (fd=" << fd << ")" << std::endl;
+    });
+
+    server.set_on_client_disconnected([](int fd) {
+        std::cout << "[INFO] 客户端断开: fd=" << fd << std::endl;
+    });
+
+    server.set_on_message([](int fd, const std::string& message) {
+        std::cout << "[INFO] 收到来自 fd=" << fd << " 的消息: " << message << std::endl;
+    });
+
+    if (!server.run()) {
+        std::cerr << "服务器启动失败，请检查上方日志" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- refactor the epoll server into a reusable `ChatServer` class with callback hooks and thread pool broadcasting
- simplify `main` to focus on configuration/logging and include the new implementation in the build
- add annotated walkthrough and beginner-friendly tutorial documentation for the project

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68cca5404af88332b8487e40cc4d6833